### PR TITLE
Define cookbook config. for pg_access.rb resource

### DIFF
--- a/resources/pg_access.rb
+++ b/resources/pg_access.rb
@@ -9,6 +9,7 @@ action :grant do
   path = "/etc/postgresql/#{new_resource.version}/main/pg_hba.conf"
   with_run_context :root do
     edit_resource(:template, path) do |new_resource|
+      cookbook 'pathfinder-mono'
       source 'pg_hba.conf.erb'
       owner 'postgres'
       group 'postgres'


### PR DESCRIPTION
This pull request prevents this cookbook for using wrong template path when this cookbook runs with another cookbook.